### PR TITLE
Use correct file path in docs and extract constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your `circle.yml` file:
 ```
 general:
   artifacts:
-    - "accesslint.log"
+    - "tmp/accesslint"
 
 machine:
   environment:

--- a/lib/accesslint/ci.rb
+++ b/lib/accesslint/ci.rb
@@ -1,4 +1,5 @@
 require "accesslint/ci/version"
+require "accesslint/ci/constants"
 require "accesslint/ci/cli"
 require "accesslint/ci/log_manager"
 require "accesslint/ci/commenter"

--- a/lib/accesslint/ci/commenter.rb
+++ b/lib/accesslint/ci/commenter.rb
@@ -78,4 +78,3 @@ module Accesslint
     end
   end
 end
-

--- a/lib/accesslint/ci/constants.rb
+++ b/lib/accesslint/ci/constants.rb
@@ -1,0 +1,9 @@
+module Accesslint
+  module Ci
+    ARTIFACTS_DIR = "tmp/accesslint"
+    LOG_FILE = "accesslint.log"
+    LOG_PATH = File.join([ARTIFACTS_DIR, LOG_FILE]).freeze
+    SITE_DIR = "accesslint-site"
+    SITE_PATH = File.join([ARTIFACTS_DIR, SITE_DIR]).freeze
+  end
+end

--- a/lib/accesslint/ci/log_manager.rb
+++ b/lib/accesslint/ci/log_manager.rb
@@ -23,8 +23,8 @@ module Accesslint
       def artifact_url
         @artifacts = JSON.parse(RestClient.get("#{artifacts_uri}?#{query}"))
 
-        artifact = @artifacts.first do |artifact|
-          artifact["path"].end_with?("accesslint.log")
+        artifact = @artifacts.first do |result|
+          result["path"].end_with?(LOG_FILE)
         end
 
         if artifact
@@ -39,7 +39,8 @@ module Accesslint
           "https://circleci.com/",
           "api/v1/project/",
           project_path,
-          "latest/artifacts",
+          "latest/artifacts/",
+          ARTIFACTS_DIR
         )
       end
 

--- a/lib/accesslint/ci/scanner.rb
+++ b/lib/accesslint/ci/scanner.rb
@@ -3,9 +3,6 @@ require "fileutils"
 
 module Accesslint
   module Ci
-    SITE_DIR = "tmp/accesslint-site".freeze
-    LOG_FILE = "tmp/accesslint.log".freeze
-
     class Scanner
       def self.perform(*args)
         new(*args).perform
@@ -21,7 +18,7 @@ module Accesslint
         create_log_file
         `#{crawl_site}`
 
-        File.read(LOG_FILE)
+        File.read(LOG_PATH)
       end
 
       private
@@ -29,17 +26,16 @@ module Accesslint
       attr_reader :host, :options
 
       def create_site_dir
-        if !File.exists?(SITE_DIR)
-          FileUtils::mkdir_p(SITE_DIR)
+        if !File.exists?(SITE_PATH)
+          FileUtils::mkdir_p(SITE_PATH)
         end
       end
 
       def create_log_file
-        if File.exists?(LOG_FILE)
-          FileUtils::rm(LOG_FILE)
+        if File.exists?(LOG_PATH)
+          FileUtils::rm(LOG_PATH)
         end
       end
-
 
       def crawl_site
         <<-SHELL
@@ -47,11 +43,11 @@ module Accesslint
             --convert-links \
             --html-extension \
             --mirror \
-            --directory-prefix #{SITE_DIR} \
+            --directory-prefix #{SITE_PATH} \
             --quiet
 
-          find #{SITE_DIR} -type f -name "*.html" | \
-            xargs -n 1 accesslint >> #{LOG_FILE}
+          find #{SITE_PATH} -type f -name "*.html" | \
+            xargs -n 1 accesslint >> #{LOG_PATH}
         SHELL
       end
     end

--- a/spec/accesslint/ci/log_manager_spec.rb
+++ b/spec/accesslint/ci/log_manager_spec.rb
@@ -7,7 +7,7 @@ module Accesslint
         context "with existing logs from a master build" do
           it "returns the existing logs" do
             allow(RestClient).to receive(:get).
-              with("https://circleci.com/api/v1/project/accesslint/accesslint-ci.rb/latest/artifacts?branch=master&filter=successful&circle-token=ABC123").
+              with("https://circleci.com/api/v1/project/accesslint/accesslint-ci.rb/latest/artifacts/tmp/accesslint?branch=master&filter=successful&circle-token=ABC123").
               and_return([
                 path: "accesslint.log",
                 url: "https://example.com/accesslint.log",
@@ -26,7 +26,7 @@ module Accesslint
         context "with no existing logs" do
           it "returns a newline" do
             allow(RestClient).to receive(:get).
-              with("https://circleci.com/api/v1/project/accesslint/accesslint-ci.rb/latest/artifacts?branch=master&filter=successful&circle-token=ABC123").
+              with("https://circleci.com/api/v1/project/accesslint/accesslint-ci.rb/latest/artifacts/tmp/accesslint?branch=master&filter=successful&circle-token=ABC123").
               and_return([].to_json)
 
             log = LogManager.get


### PR DESCRIPTION
- Extracting constants for artifact file names and directories will make
  it easier to change the artifact paths.