### PR TITLE
Use user defined GitHub user when commenting

### DIFF
--- a/lib/accesslint/ci/commenter.rb
+++ b/lib/accesslint/ci/commenter.rb
@@ -36,14 +36,16 @@ module Accesslint
       end
 
       def authentication
-        "#{ENV.fetch('ACCESSLINT_GITHUB_USER')}:#{ENV.fetch('ACCESSLINT_API_TOKEN')}"
+        "#{github_user}:#{ENV.fetch('ACCESSLINT_API_TOKEN')}"
       end
 
       def pull_request_number
-        if !ENV.fetch("CI_PULL_REQUESTS", "").empty?
-          ENV.fetch("CI_PULL_REQUESTS").match(/(\d+)/)[0]
+        if !ENV.fetch("CI_PULL_REQUEST", "").empty?
+          ENV.fetch("CI_PULL_REQUEST").split("/").last
         else
-          raise CommenterError.new("Failed to comment: missing CI_PULL_REQUESTS.")
+          raise CommenterError.new(
+            "Failed to comment: CI_PULL_REQUEST is missing."
+          )
         end
       end
 
@@ -52,12 +54,12 @@ module Accesslint
       end
 
       def github_user
-        ENV.fetch("CIRCLE_PROJECT_USERNAME")
+        ENV.fetch("ACCESSLINT_GITHUB_USER")
       end
 
       def project_path
         [
-          github_user,
+          ENV.fetch("CIRCLE_PROJECT_USERNAME"),
           ENV.fetch("CIRCLE_PROJECT_REPONAME"),
         ].join("/")
       end

--- a/spec/accesslint/ci/commenter_spec.rb
+++ b/spec/accesslint/ci/commenter_spec.rb
@@ -13,7 +13,7 @@ module Accesslint
         allow(RestClient).to receive(:get)
         allow(RestClient).to receive(:post)
 
-        ClimateControl.modify(CI_PULL_REQUESTS: pull_url) do
+        ClimateControl.modify(CI_PULL_REQUEST: pull_url) do
           Commenter.perform(errors)
         end
 


### PR DESCRIPTION
- Use singular PR name
- Split the PR URL instead of using a regex. Project names with numbers will otherwise get returned first.
- Circle CI can return the name of an org when trying to fetch the user
  name via its ENV variables.
- AccessLint API needs the username of the person that auth'd (not the
  org)
- Users must set ACCESSLINT_GITHUB_USER in Circle custom env variables.

[Closes #45]