### PR TITLE
Refine and speed up crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `circle.yml` file:
 ```
 general:
   artifacts:
-    - "tmp"
+    - "tmp/accesslint.log"
 
 machine:
   environment:


### PR DESCRIPTION
- Whitelist accepted files to fetch, instead of maintaining an
  incomplete blacklist.
- Clean up after ourselves by deleting files immediately after download.
- Log file moved to `/tmp` instead of project `tmp`, to make sure we get
  cleaned up after.
- **Respect robots.txt**. This means that the crawler will not run on pages that are disallowed by the robots.txt file.

### Before

```
time ( accesslint-ci scan --skip-ci localhost:4000; ) =>  54.27s user 56.79s system 76% cpu 2:25.77 total
```

### After

```
time ( accesslint-ci scan --skip-ci localhost:4000; ) =>  37.27s user 38.37s system 77% cpu 1:37.70 total
```