### PR TITLE
Accept a baseline file for comparison of logs

### DIFF
--- a/lib/accesslint/ci/cli.rb
+++ b/lib/accesslint/ci/cli.rb
@@ -4,10 +4,11 @@ module Accesslint
   module Ci
     class Cli < Thor
       desc "scan HOST", "scan HOST"
-      option :"skip-ci", type: :boolean
-      option :"hosted", type: :boolean
+      option :"base", type: :string
       option :"compare", type: :string
+      option :"hosted", type: :boolean
       option :"outfile", type: :string
+      option :"skip-ci", type: :boolean
       def scan(host)
         @host = host
 

--- a/spec/accesslint/ci/cli_spec.rb
+++ b/spec/accesslint/ci/cli_spec.rb
@@ -25,6 +25,7 @@ module Accesslint
             [host],
             {
               compare: previous_diff_file,
+              outfile: baseline_log_file,
               base: baseline_log_file,
             },
           )


### PR DESCRIPTION
- Baseline files can be the initial scan on master or the first scan on
  a PR.
- Subsequent scans will compare results with the baseline to determine
  if there is a diff (more or fewer errors).